### PR TITLE
feat: support nested repos and add extra placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,13 @@ Adds a button at the top of files in both Sourcegraph app and code hosts like Gi
   - `sublime` (Sublime Text, requires a URL handler installed such as [this one for macOS](https://github.com/inopinatus/sublime_url))
   - `custom` (requires also setting `openineditor.customUrlPattern`): `"openineditor.editor": "custom"`
 - `openineditor.basePath`: The absolute path on your computer where your git repositories live. This extension requires all git repos to be already cloned under this path with their original names. `"/Users/yourusername/src"` is a valid absolute path, while `"~/src"` is not.
-- `openineditor.customUrlPattern`: If you set `openineditor.editor` to `custom`, this must be set. Use placeholders `%file`, `%line`, and `%col` to mark where the file path, line number, and column number must be replaced. Example URL for IntelliJ IDEA: `idea://open?file=%file&line=%line&column=%col`
+- `openineditor.customUrlPattern`: If you set `openineditor.editor` to `custom`, this must be set. Use placeholders `%host`, `%repo`, `%filePath`, `%file`, `%line`, and `%col` to mark where the file path, line number, and column number must be replaced. Example URL for IntelliJ IDEA: `idea://open?file=%file&line=%line&column=%col`
+
+| Placeholder | Example                                                    |
+| ----------- | ---------------------------------------------------------- |
+| %host       | github.com                                                 |
+| %repo       | sourcegraph/open-in-editor-extension                       |
+| %filePath   | src/open-in-editor.ts                                      |
+| %file       | sourcegraph/open-in-editor-extension/src/open-in-editor.ts |
+| %line       | 1                                                          |
+| %col        | 1                                                          |

--- a/src/open-in-editor.ts
+++ b/src/open-in-editor.ts
@@ -50,11 +50,9 @@ function getOpenUrl(textDocumentUri: URL): URL {
         )
     }
 
-    const rawRepoName = decodeURIComponent(textDocumentUri.hostname + textDocumentUri.pathname)
-    // TODO support different folder layouts, e.g. repo nested under owner name
-    const repoBaseName = rawRepoName.split('/').pop() ?? ''
-    const relativePath = decodeURIComponent(textDocumentUri.hash.slice('#'.length))
-    const absolutePath = path.join(basePath, repoBaseName, relativePath)
+    const codeHost = textDocumentUri.host;
+    const repoName = textDocumentUri.pathname.replace(/^\//, '').replace(/\/$/, '') ?? ''
+    const filePath = decodeURIComponent(textDocumentUri.hash.slice('#'.length))
     let line = 1;
     let column = 1;
 
@@ -69,7 +67,10 @@ function getOpenUrl(textDocumentUri: URL): URL {
     }
 
     const urlPattern = getEditorUrlPattern(editor, customUrlPattern as string)
-        .replace('%file', absolutePath)
+        .replace('%host', codeHost)
+        .replace('%repo', repoName)
+        .replace('%filePath', filePath)
+        .replace('%file', path.join(basePath, repoName, filePath))
         .replace('%line', `${line}`)
         .replace('%col', `${column}`)
 


### PR DESCRIPTION
Nested repo support has been added so you can now view repositories
that have a deeper folder structure that 2.

Add extra placeholders to provide more options for directory
structures on developers workstations