### PR TITLE
feat: replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Adds a button to the Sourcegraph's extension panel and at the top of files in co
   - `custom` (requires also setting `openineditor.customUrlPattern`): `"openineditor.editor": "custom"`
 - `openineditor.basePath`: The absolute path on your computer where your git repositories live. This extension requires all git repos to be already cloned under this path with their original names. `"/Users/yourusername/src"` is a valid absolute path, while `"~/src"` is not.
 - `openineditor.customUrlPattern`: If you set `openineditor.editor` to `custom`, this must be set. Use placeholders `%file`, `%line`, and `%col` to mark where the file path, line number, and column number must be replaced. Example URL for IntelliJ IDEA: `idea://open?file=%file&line=%line&column=%col`
+- `openineditor.replacements`: Takes object, where each key is replaced by value in the final url. The key can be a string or a RegExp, and the value must be a string. For example, `"openineditor.replacements": {"(?<=Documents\/)(.*[\\\/])": "sourcegraph-$1"},` will add `sourcegraph-` in front of the string that matches the `(?<=Documents\/)(.*[\\\/])` RegExp pattern, which is the string after `Documents/` and before the final slash: `vscode://file//Users/USERNAME/Documents/REPO-NAME/package.json` => `vscode://file//Users/USERNAME/Documents/sourcegraph-REPO-NAME/package.json`
 
 ## Examples
 

--- a/src/open-in-editor.ts
+++ b/src/open-in-editor.ts
@@ -20,6 +20,7 @@ function getOpenUrl(textDocumentUri: URL): URL {
     const basePath: unknown = sourcegraph.configuration.get().value['openineditor.basePath'] as unknown
     const editor: unknown = sourcegraph.configuration.get().value['openineditor.editor'] as unknown
     const customUrlPattern: unknown = sourcegraph.configuration.get().value['openineditor.customUrlPattern'] as unknown
+    const replacements: Record<string, string> = sourcegraph.configuration.get().value['openineditor.replacements'] as Record<string, string>
     const learnMorePath = new URL('/extensions/sourcegraph/open-in-editor', sourcegraph.internal.sourcegraphURL.href).href
 
     if (typeof basePath !== 'string') {
@@ -68,14 +69,22 @@ function getOpenUrl(textDocumentUri: URL): URL {
         }
     }
 
-    const urlPattern = getEditorUrlPattern(editor, customUrlPattern as string)
+    let urlPattern = getEditorUrlPattern(editor, customUrlPattern as string)
         .replace('%file', absolutePath)
         .replace('%line', `${line}`)
         .replace('%col', `${column}`)
 
+    if(replacements) {
+        for (const replacement in replacements) {
+            if (typeof replacement === 'string') {
+                const POST_REGEX = new RegExp(replacement);
+                urlPattern = urlPattern.replace(POST_REGEX, replacements[replacement])
+            }
+        }
+    }
+
     const openUrl = new URL(urlPattern)
 
-    console.log(openUrl.href)
     return openUrl
 }
 


### PR DESCRIPTION
Add `openineditor.replacements`: Takes object, where each key is replaced by value in the final url. The key can be a string or a RegExp, and the value must be a string. 

### Example 1:
Adds `sourcegraph-` in front of the string that matches the `(?<=Documents\/)(.*[\\\/])` RegExp pattern, which is the string after `Documents/` and before the final slash.

```json
"openineditor.replacements": {"(?<=Documents\/)(.*[\\\/])": "sourcegraph-$1"},

// vscode://file//Users/USERNAME/Documents/REPO-NAME/package.json => vscode://file//Users/USERNAME/Documents/sourcegraph-REPO-NAME/package.json

````

### Example 2:
Remove `sourcegraph-` from the final URL.

```json
"openineditor.replacements": {"sourcegraph-": ""},

// vscode://file//Users/USERNAME/Documents/sourcegraph-REPO-NAME/package.json => vscode://file//Users/USERNAME/Documents/REPO-NAME/package.json

````